### PR TITLE
[BUGFIX] Return this for pipeline stages

### DIFF
--- a/src/org/typo3/chefci/v2/Pipeline.groovy
+++ b/src/org/typo3/chefci/v2/Pipeline.groovy
@@ -37,10 +37,12 @@ class Pipeline implements Serializable {
 
         def withGitCheckoutStage() {
             stages << new GitCheckout(script, 'Git Checkout')
+            return this
         }
 
         def withLintStage() {
             stages << new Lint(script, 'Linting')
+            return this
         }
 
         def build() {


### PR DESCRIPTION
In order to chain stages, very step must return `this` (=`Builder`).