### PR TITLE
Extract the timeout-ing input step into JenkinsHelper

### DIFF
--- a/src/org/typo3/chefci/helpers/JenkinsHelper.groovy
+++ b/src/org/typo3/chefci/helpers/JenkinsHelper.groovy
@@ -1,5 +1,8 @@
 package org.typo3.chefci.helpers
 
+import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
+import org.jenkinsci.plugins.workflow.support.steps.input.Rejection
+
 class JenkinsHelper implements Serializable {
     def steps
 
@@ -41,5 +44,48 @@ class JenkinsHelper implements Serializable {
      */
     def annotateBuildName(String text) {
         steps.currentBuild.displayName = "#${steps.currentBuild.getNumber()} ${text}"
+    }
+
+    /**
+     * Generates a pipeline {@code input} step that times out after a specified amount of time.
+     *
+     * The options for the timeout are supplied via {@code timeoutOptions}.
+     * The options for the input dialog are supplied via {@code inputOptions}.
+     *
+     * The returned Map contains the following keys:
+     *
+     * - proceed: true, if the Proceed button was clicked, false if aborted manually aborted or timed out
+     * - reason: 'user', if user hit Proceed or Abort; 'timeout' if input dialog timed out
+     * - submitter: name of the user that submitted or canceled the dialog
+     * - additional keys for every parameter submitted via {@code inputOptions.parameters}
+     *
+     * @param args Map containing inputOptions and timoutOptions, both passed to respective steps
+     * @return Map containing above specified keys response/reason/submitter and those for parameters
+     */
+    Map inputWithTimeout(Map args) {
+        // see https://go.cloudbees.com/docs/support-kb-articles/CloudBees-Jenkins-Enterprise/Pipeline---How-to-add-an-input-step,-with-timeout,-that-continues-if-timeout-is-reached,-using-a-default-value.html
+        try {
+            steps.timeout(args.timeoutOptions) {
+                def inputOptions = args.inputOptions
+                inputOptions.submitterParameter = "submitter"
+
+                // as we ask for the submitter, we get a Map back instead of a string
+                // besides the parameter supplied using args.inputOptions, this will include "submitter"
+                Map responseValues = steps.input args.inputOptions
+                steps.echo "Submitted by ${responseValues.submitter}"
+
+                return [proceed: true, reason: 'user'] + responseValues
+            }
+        } catch (FlowInterruptedException err) { // error means we reached timeout
+            // err.getCauses() returns [org.jenkinsci.plugins.workflow.support.steps.input.Rejection]
+            Rejection rejection = err.getCauses().first()
+
+            if ('SYSTEM' == rejection.getUser().toString()) { // user == SYSTEM means timeout.
+                return [proceed: false, reason: 'timeout']
+            } else { // explicitly aborted
+                steps.echo rejection.getShortDestepsion()
+                return [proceed: false, reason: 'user', submitter: rejection.getUser().toString()]
+            }
+        }
     }
 }

--- a/src/org/typo3/chefci/helpers/JenkinsHelper.groovy
+++ b/src/org/typo3/chefci/helpers/JenkinsHelper.groovy
@@ -2,6 +2,7 @@ package org.typo3.chefci.helpers
 
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
 import org.jenkinsci.plugins.workflow.support.steps.input.Rejection
+import com.cloudbees.groovy.cps.NonCPS
 
 class JenkinsHelper implements Serializable {
     def steps

--- a/src/org/typo3/chefci/v2/Pipeline.groovy
+++ b/src/org/typo3/chefci/v2/Pipeline.groovy
@@ -69,9 +69,9 @@ class Pipeline implements Serializable {
 
         def buildDefaultPipeline() {
             withGitCheckoutStage()
-            withLintStage()
+            // withLintStage()
             withBuildStage()
-            withAcceptanceStage()
+            // withAcceptanceStage()
             withPublishStage()
             return new Pipeline(this)
         }

--- a/src/org/typo3/chefci/v2/stages/Publish.groovy
+++ b/src/org/typo3/chefci/v2/stages/Publish.groovy
@@ -18,8 +18,23 @@ class Publish extends AbstractStage {
         }
     }
 
-    protected inputWithTimeout(Map args) {
-       def reason = null
+    /**
+     * Generates a pipeline {@code input} step that times out after a specified amount of time.
+     *
+     * The options for the timeout are supplied via {@code timeoutOptions}.
+     * The options for the input dialog are supplied via {@code inputOptions}.
+     *
+     * The returned Map contains the following keys:
+     *
+     * - response: true, if response was received, false if input manually canceled or timed out
+     * - reason: 'user', if user hit Proceed or Cancel; 'timeout' if input dialog timed out
+     * - submitter: name of the user that submitted or canceled the dialog
+     * - additional keys for every parameter submitted via {@code inputOptions.parameters}
+     *
+     * @param args Map containing inputOptions and timoutOptions, both passed to respective steps
+     * @return Map containing above specified keys response/reason/submitter and those for parameters
+     */
+    protected Map inputWithTimeout(Map args) {
         // see https://go.cloudbees.com/docs/support-kb-articles/CloudBees-Jenkins-Enterprise/Pipeline---How-to-add-an-input-step,-with-timeout,-that-continues-if-timeout-is-reached,-using-a-default-value.html
         try {
             script.timeout(args.timeoutOptions) {
@@ -27,23 +42,22 @@ class Publish extends AbstractStage {
                 inputOptions.submitterParameter = "submitter"
 
                 // as we ask for the submitter, we get a Map back instead of a string
-                Map response = script.input args.inputOptions
-                script.echo "Submitted by ${response.submitter}"
+                // besides the parameter supplied using args.inputOptions, this will include "submitter"
+                Map responseValues = script.input args.inputOptions
+                script.echo "Submitted by ${responseValues.submitter}"
 
-                return response + [reason: 'user']
+                return [response: true, reason: 'user'] + responseValues
             }
         } catch (FlowInterruptedException err) { // error means we reached timeout
             // err.getCauses() returns [org.jenkinsci.plugins.workflow.support.steps.input.Rejection]
             Rejection rejection = err.getCauses().first()
 
             if ('SYSTEM' == rejection.getUser().toString()) { // user == SYSTEM means timeout.
-                reason = 'timeout'
-            } else {
-                reason = 'user'
+                return [response: false, reason: 'timeout']
+            } else { // explicitly canceled
                 script.echo rejection.getShortDescription()
+                return [response: true, reason: 'user', submitter: rejection.getUser()]
             }
-
-            return [response: null, reason: reason]
         }
     }
 
@@ -55,36 +69,41 @@ class Publish extends AbstractStage {
         // generate the input dialog for version bump.
         // contains the choices patch/minor/major.
         // timeouts out after specified time.
-        def choice = new ChoiceParameterDefinition('version', ['patch', 'minor', 'major'] as String[], 'Version Part:')
+        def choice = new ChoiceParameterDefinition('versionBump', ['patch', 'minor', 'major'] as String[], 'Version Part:')
         def inputOptions = [message: 'Bump major, minor or patch version?', parameters: [choice]]
         def timeoutOptions = [time: 15, unit: 'SECONDS']
 
         // call the input dialog
+        // this will return something like
+        // [response: true, reason:user, submitter:johndoe, versionBump:patch]
+        // [response: false, reason:timeout]
         Map input = inputWithTimeout([inputOptions: inputOptions, timeoutOptions: timeoutOptions])
+
 
         script.echo "Got input ${input}"
 
-//        script.node {
-//            def jenkinsHelper = new JenkinsHelper(script)
-//
-//            if (inputValues.version) {
-//                // TODO get rid of `bundle install`
-//                script.sh 'chef exec bundle install'
-//                // TODO make thor-scmversion globally accessible and get rid of `Thorfile`
-//                // TODO see http://stackoverflow.com/questions/41474735/use-global-thorfile/41474996
-//                script.sh "chef exec thor version:bump ${versionPart}"
-//                def newVersion = script.readFile('VERSION')
-//                // TODO enable Jenkins to push to Github
-//                // sh("git push origin ${newVersion}")
-//                // TODO remove comment once we've finished this...
-//                //script.sh("berks upload")
-//                script.echo "Could upload now"
-//                jenkinsHelper.annotateBuildName(" - ${newVersion} (${versionPart})")
-//            } else {
-//                jenkinsHelper.annotateBuildName("(no upload)")
-//                script.echo "No cookbook upload was triggered within timeout"
-//            }
-//        }
+        script.node {
+            def jenkinsHelper = new JenkinsHelper(script)
+
+            // if we don't get any user response, we do nothing
+            if (input.response) {
+                // TODO get rid of `bundle install`
+                script.sh 'chef exec bundle install'
+                // TODO make thor-scmversion globally accessible and get rid of `Thorfile`
+                // TODO see http://stackoverflow.com/questions/41474735/use-global-thorfile/41474996
+                script.sh "chef exec thor version:bump ${input.versionBump}"
+                def newVersion = script.readFile('VERSION')
+                // TODO enable Jenkins to push to Github
+                // sh("git push origin ${newVersion}")
+                // TODO remove comment once we've finished this...
+                //script.sh("berks upload")
+                script.echo "Could upload now"
+                jenkinsHelper.annotateBuildName(" - ${newVersion} (${input.versionBup})")
+            } else {
+                jenkinsHelper.annotateBuildName("(no upload)")
+                script.echo "No cookbook upload was triggered within timeout"
+            }
+        }
     }
 
 }

--- a/src/org/typo3/chefci/v2/stages/Publish.groovy
+++ b/src/org/typo3/chefci/v2/stages/Publish.groovy
@@ -19,7 +19,7 @@ class Publish extends AbstractStage {
     }
 
     protected inputWithTimeout(Map args) {
-        def versionPart = null
+        def response = null
         def reason = null
         // see https://go.cloudbees.com/docs/support-kb-articles/CloudBees-Jenkins-Enterprise/Pipeline---How-to-add-an-input-step,-with-timeout,-that-continues-if-timeout-is-reached,-using-a-default-value.html
         try {
@@ -27,9 +27,9 @@ class Publish extends AbstractStage {
                 def inputOptions = args.inputOptions
                 inputOptions.submitterParameter = "submitter"
 
-                def response = script.input inputOptions
-                println response
+                response = script.input inputOptions
                 reason = response.submitter
+                script.echo "Submitted by ${reason}"
             }
         } catch (FlowInterruptedException err) { // error means we reached timeout
             // err.getCauses() returns [org.jenkinsci.plugins.workflow.support.steps.input.Rejection]
@@ -41,7 +41,7 @@ class Publish extends AbstractStage {
                 script.echo rejection.getShortDescription()
             }
         }
-        [response: versionPart, reason: reason]
+        response
     }
 
     protected publish() {
@@ -51,8 +51,8 @@ class Publish extends AbstractStage {
 
         // generate the input dialog for version bump.
         // contains the choices patch/minor/major.
-        // timeous out after specified time.
-        def choice = new ChoiceParameterDefinition('Version Part:', ['patch', 'minor', 'major'] as String[], '')
+        // timeouts out after specified time.
+        def choice = new ChoiceParameterDefinition('version', ['patch', 'minor', 'major'] as String[], 'Version Part:')
         def inputOptions = [message: 'Bump major, minor or patch version?', parameters: [choice]]
         def timeoutOptions = [time: 15, unit: 'SECONDS']
 

--- a/src/org/typo3/chefci/v2/stages/Publish.groovy
+++ b/src/org/typo3/chefci/v2/stages/Publish.groovy
@@ -23,11 +23,14 @@ class Publish extends AbstractStage {
         def didTimeout = false
         def versionPart
 
+        def choice = new ChoiceParameterDefinition('Version Part:', ['patch', 'minor', 'major'] as String[], '')
+        def inputOptions = [message: 'Bump major, minor or patch version?', parameters: [choice]]
+        def timeoutOptions = [time: 15, unit: 'SECONDS']
+
         // see https://go.cloudbees.com/docs/support-kb-articles/CloudBees-Jenkins-Enterprise/Pipeline---How-to-add-an-input-step,-with-timeout,-that-continues-if-timeout-is-reached,-using-a-default-value.html
         try {
-            script.timeout(time: 15, unit: 'SECONDS') {
-                def choice = new ChoiceParameterDefinition('Version Part:', ['patch', 'minor', 'major'] as String[], '')
-                versionPart = script.input message: 'Bump major, minor or patch version?', parameters: [choice]
+            script.timeout(timeoutOptions) {
+                versionPart = script.input inputOptions
             }
         } catch (FlowInterruptedException err) { // error means we reached timeout
             // err.getCauses() returns [org.jenkinsci.plugins.workflow.support.steps.input.Rejection]

--- a/src/org/typo3/chefci/v2/stages/Publish.groovy
+++ b/src/org/typo3/chefci/v2/stages/Publish.groovy
@@ -7,8 +7,11 @@ import org.typo3.chefci.helpers.JenkinsHelper
 
 class Publish extends AbstractStage {
 
+    JenkinsHelper jenkinsHelper
+
     Publish(Object script, String stageName) {
         super(script, stageName)
+        jenkinsHelper = new JenkinsHelper(script)
     }
 
     @Override
@@ -61,11 +64,40 @@ class Publish extends AbstractStage {
         }
     }
 
+    /**
+     * Asks the user whether the cookbook should be uploaded
+     */
     protected publish() {
-        def userInput = true
-        def didTimeout = false
-        def versionPart
 
+        def userInput = getInput()
+
+        def newVersion
+        // if we don't get any user response, we do nothing
+        if (userInput.response) {
+            script.node{
+                newVersion = bumpVersion(userInput.versionBump)
+                upload()
+            }
+            // set the build name to something meaningful, i.e.
+            // #1 - 1.2.3 (patch)
+            jenkinsHelper.annotateBuildName(" - ${newVersion} (${userInput.versionBump})")
+
+        } else {
+            script.echo "No cookbook upload was triggered within timeout"
+            jenkinsHelper.annotateBuildName("(no upload)")
+        }
+    }
+
+    /**
+     * Asks the user for his/her opinion, if we should bump the version number and then upload this.
+     *
+     *  this will return something like
+     *  [response: true, reason:user, submitter:johndoe, versionBump:patch]
+     *  [response: false, reason:timeout]
+     *
+     * @return Map response options
+     */
+    protected Map getInput() {
         // generate the input dialog for version bump.
         // contains the choices patch/minor/major.
         // timeouts out after specified time.
@@ -74,36 +106,42 @@ class Publish extends AbstractStage {
         def timeoutOptions = [time: 15, unit: 'SECONDS']
 
         // call the input dialog
-        // this will return something like
-        // [response: true, reason:user, submitter:johndoe, versionBump:patch]
-        // [response: false, reason:timeout]
-        Map input = inputWithTimeout([inputOptions: inputOptions, timeoutOptions: timeoutOptions])
+        Map inputValues = inputWithTimeout([inputOptions: inputOptions, timeoutOptions: timeoutOptions])
 
+        script.echo "Got input ${inputValues}"
 
-        script.echo "Got input ${input}"
-
-        script.node {
-            def jenkinsHelper = new JenkinsHelper(script)
-
-            // if we don't get any user response, we do nothing
-            if (input.response) {
-                // TODO get rid of `bundle install`
-                script.sh 'chef exec bundle install'
-                // TODO make thor-scmversion globally accessible and get rid of `Thorfile`
-                // TODO see http://stackoverflow.com/questions/41474735/use-global-thorfile/41474996
-                script.sh "chef exec thor version:bump ${input.versionBump}"
-                def newVersion = script.readFile('VERSION')
-                // TODO enable Jenkins to push to Github
-                // sh("git push origin ${newVersion}")
-                // TODO remove comment once we've finished this...
-                //script.sh("berks upload")
-                script.echo "Could upload now"
-                jenkinsHelper.annotateBuildName(" - ${newVersion} (${input.versionBump})")
-            } else {
-                jenkinsHelper.annotateBuildName("(no upload)")
-                script.echo "No cookbook upload was triggered within timeout"
-            }
-        }
+        inputValues
     }
 
+    /**
+     * Increases the version number by level {@code level} using thor-scmversion and pushes git tag.
+     *
+     * @param level patch/minor/major
+     * @return new version number
+     */
+    protected String bumpVersion(String level) {
+        // TODO get rid of `bundle install`
+        script.sh 'chef exec bundle install'
+        // TODO make thor-scmversion globally accessible and get rid of `Thorfile`
+        // TODO see http://stackoverflow.com/questions/41474735/use-global-thorfile/41474996
+        script.sh "chef exec thor version:bump ${level}"
+        def newVersion = script.readFile('VERSION')
+        // TODO enable Jenkins to push to Github
+        // sh("git push origin ${newVersion}")
+
+        newVersion
+    }
+
+
+    /**
+     * Uploads the cookbook
+     *
+     * @param userInput
+     * @return
+     */
+    protected upload() {
+        // TODO remove comment once we've finished this...
+        //script.sh("berks upload")
+        script.echo "Could upload now"
+    }
 }

--- a/src/org/typo3/chefci/v2/stages/Publish.groovy
+++ b/src/org/typo3/chefci/v2/stages/Publish.groovy
@@ -98,7 +98,7 @@ class Publish extends AbstractStage {
                 // TODO remove comment once we've finished this...
                 //script.sh("berks upload")
                 script.echo "Could upload now"
-                jenkinsHelper.annotateBuildName(" - ${newVersion} (${input.versionBup})")
+                jenkinsHelper.annotateBuildName(" - ${newVersion} (${input.versionBump})")
             } else {
                 jenkinsHelper.annotateBuildName("(no upload)")
                 script.echo "No cookbook upload was triggered within timeout"

--- a/src/org/typo3/chefci/v2/stages/Publish.groovy
+++ b/src/org/typo3/chefci/v2/stages/Publish.groovy
@@ -28,7 +28,7 @@ class Publish extends AbstractStage {
                 inputOptions.submitterParameter = "submitter"
 
                 def response = script.input inputOptions
-                script.echo response
+                println response
                 reason = response.submitter
             }
         } catch (FlowInterruptedException err) { // error means we reached timeout

--- a/src/org/typo3/chefci/v2/stages/Publish.groovy
+++ b/src/org/typo3/chefci/v2/stages/Publish.groovy
@@ -20,7 +20,7 @@ class Publish extends AbstractStage {
 
     protected inputWithTimeout(Map args) {
         def response = null
-        Map reason = null
+        def reason = null
         // see https://go.cloudbees.com/docs/support-kb-articles/CloudBees-Jenkins-Enterprise/Pipeline---How-to-add-an-input-step,-with-timeout,-that-continues-if-timeout-is-reached,-using-a-default-value.html
         try {
             script.timeout(args.timeoutOptions) {

--- a/src/org/typo3/chefci/v2/stages/Publish.groovy
+++ b/src/org/typo3/chefci/v2/stages/Publish.groovy
@@ -61,7 +61,7 @@ class Publish extends AbstractStage {
         def timeoutOptions = [time: 15, unit: 'SECONDS']
 
         // call the input dialog
-        Map inputValues = jenkinsHelper.HinputWithTimeout([inputOptions: inputOptions, timeoutOptions: timeoutOptions])
+        Map inputValues = jenkinsHelper.inputWithTimeout([inputOptions: inputOptions, timeoutOptions: timeoutOptions])
 
         script.echo "Got input ${inputValues}"
 

--- a/src/org/typo3/chefci/v2/stages/Publish.groovy
+++ b/src/org/typo3/chefci/v2/stages/Publish.groovy
@@ -20,16 +20,16 @@ class Publish extends AbstractStage {
 
     protected inputWithTimeout(Map args) {
         def response = null
-        def reason = null
+        Map reason = null
         // see https://go.cloudbees.com/docs/support-kb-articles/CloudBees-Jenkins-Enterprise/Pipeline---How-to-add-an-input-step,-with-timeout,-that-continues-if-timeout-is-reached,-using-a-default-value.html
         try {
             script.timeout(args.timeoutOptions) {
                 def inputOptions = args.inputOptions
                 inputOptions.submitterParameter = "submitter"
 
-                response = script.input inputOptions
+                response = script.input args.inputOptions
+                script.echo "Submitted by ${response.submitter}"
                 reason = response.submitter
-                script.echo "Submitted by ${reason}"
             }
         } catch (FlowInterruptedException err) { // error means we reached timeout
             // err.getCauses() returns [org.jenkinsci.plugins.workflow.support.steps.input.Rejection]
@@ -41,7 +41,7 @@ class Publish extends AbstractStage {
                 script.echo rejection.getShortDescription()
             }
         }
-        response
+        response + [reason: reason]
     }
 
     protected publish() {
@@ -57,8 +57,9 @@ class Publish extends AbstractStage {
         def timeoutOptions = [time: 15, unit: 'SECONDS']
 
         // call the input dialog
-        Map inputValues = inputWithTimeout([inputOptions: inputOptions, timeoutOptions: timeoutOptions])
+        Map input = inputWithTimeout([inputOptions: inputOptions, timeoutOptions: timeoutOptions])
 
+        println "Got input ${input}"
 
 //        script.node {
 //            def jenkinsHelper = new JenkinsHelper(script)

--- a/src/org/typo3/chefci/v2/stages/Publish.groovy
+++ b/src/org/typo3/chefci/v2/stages/Publish.groovy
@@ -59,7 +59,7 @@ class Publish extends AbstractStage {
         // call the input dialog
         Map input = inputWithTimeout([inputOptions: inputOptions, timeoutOptions: timeoutOptions])
 
-        println "Got input ${input}"
+        script.echo "Got input ${input}"
 
 //        script.node {
 //            def jenkinsHelper = new JenkinsHelper(script)

--- a/src/org/typo3/chefci/v2/stages/Publish.groovy
+++ b/src/org/typo3/chefci/v2/stages/Publish.groovy
@@ -1,8 +1,6 @@
 package org.typo3.chefci.v2.stages
 
 import hudson.model.ChoiceParameterDefinition
-import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
-import org.jenkinsci.plugins.workflow.support.steps.input.Rejection
 import org.typo3.chefci.helpers.JenkinsHelper
 
 class Publish extends AbstractStage {
@@ -22,49 +20,6 @@ class Publish extends AbstractStage {
     }
 
     /**
-     * Generates a pipeline {@code input} step that times out after a specified amount of time.
-     *
-     * The options for the timeout are supplied via {@code timeoutOptions}.
-     * The options for the input dialog are supplied via {@code inputOptions}.
-     *
-     * The returned Map contains the following keys:
-     *
-     * - proceed: true, if the Proceed button was clicked, false if aborted manually aborted or timed out
-     * - reason: 'user', if user hit Proceed or Abort; 'timeout' if input dialog timed out
-     * - submitter: name of the user that submitted or canceled the dialog
-     * - additional keys for every parameter submitted via {@code inputOptions.parameters}
-     *
-     * @param args Map containing inputOptions and timoutOptions, both passed to respective steps
-     * @return Map containing above specified keys response/reason/submitter and those for parameters
-     */
-    protected Map inputWithTimeout(Map args) {
-        // see https://go.cloudbees.com/docs/support-kb-articles/CloudBees-Jenkins-Enterprise/Pipeline---How-to-add-an-input-step,-with-timeout,-that-continues-if-timeout-is-reached,-using-a-default-value.html
-        try {
-            script.timeout(args.timeoutOptions) {
-                def inputOptions = args.inputOptions
-                inputOptions.submitterParameter = "submitter"
-
-                // as we ask for the submitter, we get a Map back instead of a string
-                // besides the parameter supplied using args.inputOptions, this will include "submitter"
-                Map responseValues = script.input args.inputOptions
-                script.echo "Submitted by ${responseValues.submitter}"
-
-                return [proceed: true, reason: 'user'] + responseValues
-            }
-        } catch (FlowInterruptedException err) { // error means we reached timeout
-            // err.getCauses() returns [org.jenkinsci.plugins.workflow.support.steps.input.Rejection]
-            Rejection rejection = err.getCauses().first()
-
-            if ('SYSTEM' == rejection.getUser().toString()) { // user == SYSTEM means timeout.
-                return [proceed: false, reason: 'timeout']
-            } else { // explicitly aborted
-                script.echo rejection.getShortDescription()
-                return [proceed: false, reason: 'user', submitter: rejection.getUser().toString()]
-            }
-        }
-    }
-
-    /**
      * Asks the user whether the cookbook should be uploaded
      */
     protected publish() {
@@ -74,7 +29,7 @@ class Publish extends AbstractStage {
         def newVersion
         // if we don't get any user response, we do nothing
         if (userInput.proceed) {
-            script.node{
+            script.node {
                 newVersion = bumpVersion(userInput.versionBump)
                 upload()
             }
@@ -106,7 +61,7 @@ class Publish extends AbstractStage {
         def timeoutOptions = [time: 15, unit: 'SECONDS']
 
         // call the input dialog
-        Map inputValues = inputWithTimeout([inputOptions: inputOptions, timeoutOptions: timeoutOptions])
+        Map inputValues = jenkinsHelper.HinputWithTimeout([inputOptions: inputOptions, timeoutOptions: timeoutOptions])
 
         script.echo "Got input ${inputValues}"
 
@@ -131,7 +86,6 @@ class Publish extends AbstractStage {
 
         newVersion
     }
-
 
     /**
      * Uploads the cookbook

--- a/src/org/typo3/chefci/v2/stages/Publish.groovy
+++ b/src/org/typo3/chefci/v2/stages/Publish.groovy
@@ -41,7 +41,7 @@ class Publish extends AbstractStage {
                 script.echo rejection.getShortDescription()
             }
         }
-        response + [reason: reason]
+        [response: response, reason: reason]
     }
 
     protected publish() {


### PR DESCRIPTION
This makes to code inside the Publish stage a lot more readable, as all the handling of the `input`step is hidden.