### PR TITLE
[FEATURE] Allow to specify version increment from commit subject

### DIFF
--- a/vars/gitCommit.groovy
+++ b/vars/gitCommit.groovy
@@ -1,5 +1,5 @@
 #!/usr/bin/groovy
 
-String call() {
-    sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
+String call(String sha = 'HEAD') {
+    sh(returnStdout: true, script: 'git rev-parse ' + sha).trim()
 }

--- a/vars/gitCommit.txt
+++ b/vars/gitCommit.txt
@@ -1,5 +1,5 @@
 <strong>gitCommit()</strong>
 
-<p>Determines the current git revision in the workspace. The revision is returned directly as a string, shortened to 7 characters (<code>git rev-parse --short HEAD</code>.</p>
+<p>Determines the current git revision in the workspace. The revision is returned directly as a string (<code>git rev-parse HEAD</code>.</p>
 <p>This function must be executed in a <code>node</code> context as it requires a workspace.</p>
 

--- a/vars/gitCommitMessage.groovy
+++ b/vars/gitCommitMessage.groovy
@@ -1,0 +1,5 @@
+#!/usr/bin/groovy
+
+String call(String sha = 'HEAD') {
+    sh(returnStdout: true, script: 'git show -s --format=%B ' + sha).trim()
+}

--- a/vars/gitCommitSubject.groovy
+++ b/vars/gitCommitSubject.groovy
@@ -1,0 +1,5 @@
+#!/usr/bin/groovy
+
+String call(String sha = 'HEAD') {
+    sh(returnStdout: true, script: 'git show -s --format=%s ' + sha).trim()
+}


### PR DESCRIPTION
This parses the *last* commit's *subject* for occurrences of

- #patch
- #minor
- #major

If any of these is found, the input dialog is not shown and the
version is bumped directly.

I am open to an extension to parse all commits instead of only
the last one.