### PR TITLE
Switch integration tests to kitchen-dokken

### DIFF
--- a/resources/cookbook/.kitchen.docker.yml
+++ b/resources/cookbook/.kitchen.docker.yml
@@ -1,6 +1,0 @@
-driver:
-  name: docker
-  use_sudo: false
-  provision_command:
-    - sed -i -e 's/httpredir.debian.org/ftp.de.debian.org/g' /etc/apt/sources.list || true
-    - apt-get update && apt-get install -y net-tools cron

--- a/src/org/typo3/chefci/v2/cookbook/CookbookPipeline.groovy
+++ b/src/org/typo3/chefci/v2/cookbook/CookbookPipeline.groovy
@@ -63,7 +63,6 @@ class CookbookPipeline implements Serializable {
 
         def withAcceptanceStage() {
             stages << new Acceptance(script, jenkinsHelper, slack)
-                    .setKitchenLocalYml('.kitchen.docker.yml')
             return this
         }
 

--- a/src/org/typo3/chefci/v2/cookbook/stages/Acceptance.groovy
+++ b/src/org/typo3/chefci/v2/cookbook/stages/Acceptance.groovy
@@ -6,10 +6,9 @@ import org.typo3.chefci.v2.shared.stages.AbstractStage
 
 class Acceptance extends AbstractStage {
     /**
-     Name of the file that is placed inside the cookbook folder.
-     Can be changed using setKitchenLocalYml('.kitchen.docker.yml')
+     * .kitchen.dokken.yml
      */
-    def kitchenLocalYmlName = '.kitchen.local.yml'
+    def kitchenDokkenYmlName = '.kitchen.dokken.yml'
 
     /**
      * Name of the stashed cookbook contents. Does not really matter.
@@ -30,7 +29,7 @@ class Acceptance extends AbstractStage {
 
     protected testKitchen() {
         script.node {
-            createKitchenYaml()
+            checkKitchenDokkenYaml()
             script.stash stashName
         }
 
@@ -38,18 +37,12 @@ class Acceptance extends AbstractStage {
     }
 
     /**
-     * Checks if a local kitchen config file (defaults to .kitchen.local.yml) already exists
-     * and places the one from this library otherwise (resources/cookbook/ folder).
+     * Verifies that the .kitchen.dokken.yml exists in the repo, fails otherwise.
      */
-    protected createKitchenYaml() {
+    protected checkKitchenDokkenYaml() {
 
-        if (!kitchenLocalYmlName) {
-            script.echo "No local kitchen config file specified. Doing nothing."
-        } else if (script.fileExists(kitchenLocalYmlName)) {
-            script.echo "Using the cookbook's ${kitchenLocalYmlName}"
-        } else {
-            script.echo "Placing default ${kitchenLocalYmlName} file in workspace"
-            jenkinsHelper.copyGlobalLibraryScript "cookbook/${kitchenLocalYmlName}", kitchenLocalYmlName
+        if (! script.fileExists(kitchenDokkenYmlName)) {
+            script.error "Did not find a ${kitchenDokkenYmlName} in the repository. Please add one."
         }
     }
 
@@ -82,7 +75,7 @@ class Acceptance extends AbstractStage {
         script.node {
             script.unstash stashName
 
-            script.withEnv(["KITCHEN_LOCAL_YAML=${kitchenLocalYmlName}"]) {
+            script.withEnv(["KITCHEN_LOCAL_YAML=${kitchenDokkenYmlName}"]) {
                 // read out the list of test instances from `kitchen list`
                 lines = script.sh(script: 'kitchen list', returnStdout: true).split('\n')
             }
@@ -109,7 +102,7 @@ class Acceptance extends AbstractStage {
                 script.unstash stashName
 
                 script.wrap([$class: 'AnsiColorBuildWrapper', colorMapName: "XTerm"]) {
-                    script.withEnv(["KITCHEN_LOCAL_YAML=${kitchenLocalYmlName}"]) {
+                    script.withEnv(["KITCHEN_LOCAL_YAML=${kitchenDokkenYmlName}"]) {
                         try {
                             script.sh script: "kitchen test --destroy always ${instanceName}"
                         } catch (err) {
@@ -128,7 +121,7 @@ class Acceptance extends AbstractStage {
      * @param filename
      */
     void setKitchenLocalYml(String filename) {
-        kitchenLocalYmlName = filename
+        kitchenDokkenYmlName = filename
         this
     }
 


### PR DESCRIPTION
# About Kitchen-Dokken

[kitchen-dokken](https://github.com/someara/kitchen-dokken) is nowadays the preferred way to run test-kitchen in Docker. Compared to _kitchen-docker_, it causes less trouble with service handling and also uses a more Docker-style approach (using volumes for `/opt/chef` etc).
We see such issues once again in TYPO3-cookbooks/t3-base#1.

See also the [sous-chefs](https://github.com/sous-chefs/) cookbooks for examples using _kitchen-dokken_.

**So this PR is about switching the CI pipeline from _kitchen-docker_ to _kitchen-dokken_.**

# Changes

The pipeline execution in Jenkins is changed as follows:

- check that a `.kitchen.dokken.yml` file exists in the cookbook repository (and fail otherwise)
- drop the previous behavior, which would not fail the build, but place a `.kitchen.docker.yml` in the workspace
- call test-kitchen using `KITCHEN_LOCAL_YAML=.kitchen.dokken.yml kitchen test <instance>`, which merges it with `.kitchen.yml`.

The reason for not automatically creating the `.kitchen.dokken.yml` file in the workspace as we did before is filed in someara/kitchen-dokken#91. If this feature gets implemented, we might change that logic again.

So long, we have to add the `.kitchen.dokken.yml` file to every cookbook, as it is [here in t3-base](https://github.com/TYPO3-cookbooks/t3-base/blob/kitchen-dokken/.kitchen.dokken.yml).

# Testing

The `kitchen-dokken` branches of [t3-base](https://github.com/TYPO3-cookbooks/t3-base/blob/kitchen-dokken/Jenkinsfile#L1) and [site-skeletontypo3org](https://github.com/TYPO3-cookbooks/site-skeletontypo3org/blob/kitchen-dokken/Jenkinsfile#L1) have an adjusted `Jenkinsfile` to already use this branch here from the pipeline instead of _master_. This would _not_ be part of the finally merged version.

The **Chef-CI** logs for those two cookbooks can be seen [here](https://chef-ci.typo3.org/job/TYPO3-cookbooks/job/t3-base/job/kitchen-dokken/9/display/redirect) and [here](https://chef-ci.typo3.org/job/TYPO3-cookbooks/job/site-skeletontypo3org/job/kitchen-dokken/9/display/redirect).

For **local testing**, you can use the following command, as also described in the comments of the `.kitchen.dokken.yml` files:

    KITCHEN_LOCAL_YAML=.kitchen.dokken.yml kitchen verify

This uses `.kitchen.yml` and merges it with the `.kitchen.dokken.yml` (instead of `.kitchen.local.yml`, which would be used otherwise). This setup is recommended in the [_kitchen-dokken_ README](https://github.com/someara/kitchen-dokken#usage), and also used by [_sous-chefs_ for testing in TravisCI](https://github.com/sous-chefs/haproxy/blob/62a7fcbf51664bc48a9449e29ffecc6619473471/.travis.yml#L40).